### PR TITLE
Show commands output in realtime

### DIFF
--- a/fs_radar/__main__.py
+++ b/fs_radar/__main__.py
@@ -119,9 +119,9 @@ def setup_logs(args):
 
 def get_pairs_filter2launch_pads(cfg):
     '''Generate a list o pairs (path_filter, launch pad)'''
-    for group in cfg['group'].values():
+    for name, group in cfg['group'].items():
         path_filter = makePathFilter(group['rules'])
-        lp = CmdLaunchPad(group['cmd'])
+        lp = CmdLaunchPad(group['cmd'], name=name)
         yield (path_filter, lp)
 
 

--- a/fs_radar/cmd_launch_pad.py
+++ b/fs_radar/cmd_launch_pad.py
@@ -85,7 +85,7 @@ class CmdLaunchPad(Thread):
                 self.terminate_process()
                 break
             elif self.timed_out_event.is_set():
-                self.adapter.info('### END (process timed out) ###')
+                self.adapter.info('### END PROCESS - %s ###', error('timed out'))
                 self.on_process_timed_out()
 
             readers = [
@@ -130,9 +130,9 @@ class CmdLaunchPad(Thread):
             self.adapter.info('%s', output.strip())
         else:
             if exit_status == 0:
-                self.adapter.info('### END (status %s) ###', success(exit_status))
+                self.adapter.info('### END PROCESS - exit status %s ###', success(exit_status))
             else:
-                self.adapter.info('### END (status %s) ###', error(exit_status))
+                self.adapter.info('### END PROCESS - exit status %s ###', error(exit_status))
 
             self.p = None
 

--- a/fs_radar/cmd_launch_pad.py
+++ b/fs_radar/cmd_launch_pad.py
@@ -123,7 +123,7 @@ class CmdLaunchPad(Thread):
             self.run_process(self.cmd_template, parameter)
 
     def on_process_queue_item_received(self, item):
-        exit_status, cmd, output = item
+        exit_status, output = item
 
         if exit_status is None:
             # process produced output and is still running
@@ -152,10 +152,11 @@ class CmdLaunchPad(Thread):
             self.timed_out_event
         ))
         self.p.start()
+        # run_command_with_queue(cmd_line, self.queue_process)
 
 
-def _make_callback_on_process_line_read(cmd, queue):
-    return lambda exit_status, line: queue.put((exit_status, cmd, line))
+def _make_callback_on_process_line_read(queue):
+    return lambda exit_status, line: queue.put((exit_status, line))
 
 
 def run_command_with_queue(cmd, timeout, queue, timed_out_event):
@@ -171,7 +172,7 @@ def run_command_with_queue(cmd, timeout, queue, timed_out_event):
     @param multiprocessing.Event timed_out_event event set if the process times out
     '''
     p = fs_radar.shell_process.popen_shell_command(cmd)
-    callback = _make_callback_on_process_line_read(cmd, queue)
+    callback = _make_callback_on_process_line_read(queue)
     try:
         fs_radar.shell_process.consume_output_line_by_line(p, callback, timeout=timeout)
     except subprocess.TimeoutExpired:

--- a/fs_radar/shell_process.py
+++ b/fs_radar/shell_process.py
@@ -1,3 +1,4 @@
+from time import time
 import os
 import pty
 import select
@@ -30,12 +31,15 @@ def popen_shell_command(cmd, merge_stderr=True):
         stderr=subprocess.STDOUT if merge_stderr else None,
         start_new_session=True
     )
+
+    p.start_time = time()
+
     os.close(slave)  # no need to have slave open on master's process
 
     return p
 
 
-def consume_output_line_by_line(p, callback, encoding='utf-8'):
+def consume_output_line_by_line(p, callback, timeout=None, encoding='utf-8'):
     '''
     Read a process' output.
     Every time a line is read call `callback` with two arguments,
@@ -47,22 +51,40 @@ def consume_output_line_by_line(p, callback, encoding='utf-8'):
     @param string cmd the command to run
     @param func callback the function to run on each line read. It will receive
                 two arguments, the exit status code (or None) and the line read
+    @param int timeout max time to complete the process. If the timeout expires
+               the process is killed and subprocess.TimeoutExpired is raised
     @param encoding the encoding of the running shell
     @return None
     '''
 
+    start_time = p.start_time or time()
+
     while True:
         data = ''
-        r, w, x = select.select([p.stdout], [], [], 10)
+        r, w, x = select.select([p.stdout], [], [], 1)
         if r:
             data = r[0].readline()
             if data:
                 callback(None, data.decode(encoding).rstrip())
 
+        time_left = timeout is not None and max(0, start_time + timeout - time())
+
         if not data and p.returncode is not None:
             # Terminate when we've read all the output and the returncode is set
             break
+        elif timeout is not None and time_left == 0:
+            _stop_process(p)
+            raise subprocess.TimeoutExpired(p.args, timeout)
 
         p.poll()  # updates returncode so we can exit the loop
 
     callback(p.returncode, '')
+
+
+def _stop_process(p):
+    try:
+        # give the process a chance to exit cleanly
+        p.terminate()
+        p.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        p.kill()

--- a/fs_radar/shell_process.py
+++ b/fs_radar/shell_process.py
@@ -1,0 +1,68 @@
+import os
+import pty
+import select
+import subprocess
+
+
+def popen_shell_command(cmd, merge_stderr=True):
+    '''Spawn a process to run `cmd`
+
+    @param string cmd the command to run
+    @param bool merge_stderr whether to read from stderr too (default True)
+    @return object a Popen instance
+    '''
+
+    # 1. /usr/bin/env bash because not everyone has bash in /bin/
+    # 2. -l because we want to read .bash_profile or brothers
+    # 3. -i because -l isn't enough
+    # 4. use a pty because it's required by using -i
+    # 5. start_new_session because otherwise we get
+    # bash: cannot set terminal process group (-1): Inappropriate ioctl for device
+    # bash: no job control in this shell
+    # (it also sets a process group so if we kill the shell we kill
+    # the subprocess too)
+    master, slave = pty.openpty()
+    args = ['/usr/bin/env', 'bash', '-i', '-l', '-c', cmd]
+    p = subprocess.Popen(
+        args,
+        stdin=slave,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT if merge_stderr else None,
+        start_new_session=True
+    )
+    os.close(slave)  # no need to have slave open on master's process
+
+    return p
+
+
+def consume_output_line_by_line(p, callback, encoding='utf-8'):
+    '''
+    Read a process' output.
+    Every time a line is read call `callback` with two arguments,
+    the current exit status code and the read line.
+    As long as the process is running the exit status code is None and
+    the line is non-empty. When the process terminates `callback` will be
+    called one last time with the exit status code and an empty-string.
+
+    @param string cmd the command to run
+    @param func callback the function to run on each line read. It will receive
+                two arguments, the exit status code (or None) and the line read
+    @param encoding the encoding of the running shell
+    @return None
+    '''
+
+    while True:
+        data = ''
+        r, w, x = select.select([p.stdout], [], [], 10)
+        if r:
+            data = r[0].readline()
+            if data:
+                callback(None, data.decode(encoding).rstrip())
+
+        if not data and p.returncode is not None:
+            # Terminate when we've read all the output and the returncode is set
+            break
+
+        p.poll()  # updates returncode so we can exit the loop
+
+    callback(p.returncode, '')


### PR DESCRIPTION
Sometimes  commands may require a long time to complete.
We don't want the program to be silent until the subprocess is completed, we want to show the output as soon as it is generated.

Since we can have commands running in parallel the output may become interlaced: we'll have to add the command's group name to the logs.
